### PR TITLE
Added registry.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.pyc
 node_modules/*
 .idea
+.cache/

--- a/registry.json
+++ b/registry.json
@@ -1,0 +1,20 @@
+{
+    "datapackage": {
+        "title": "Data Package",
+        "schema": "http://schemas.datapackages.org/data-package.json",
+        "schema_path": "data-package.json",
+        "specification": "http://dataprotocols.org/data-packages"
+    },
+    "tabular-datapackage": {
+        "title": "Tabular Data Package",
+        "schema": "http://schemas.datapackages.org/tabular-data-package.json",
+        "schema_path": "tabular-data-package.json",
+        "specification": "http://dataprotocols.org/tabular-data-package/"
+    },
+    "fiscal-datapackage": {
+        "title": "Fiscal Data Package",
+        "schema": "http://schemas.datapackages.org/fiscal-data-package.json",
+        "schema_path": "fiscal-data-package.json",
+        "specification": "http://fiscal.dataprotocols.org/spec/"
+    }
+}

--- a/tests/test_registry_json.py
+++ b/tests/test_registry_json.py
@@ -1,0 +1,87 @@
+import io
+import os
+import json
+import unittest
+import urllib.request
+
+BASE_PATH = os.path.abspath(
+    os.path.join(
+        os.path.dirname(__file__),
+        '..'
+    )
+)
+REGISTRY_PATH = os.path.join(BASE_PATH, 'registry.json')
+
+
+class TestRegistryJson(unittest.TestCase):
+    def test_registry_has_the_expected_headers(self):
+        expected_headers = (
+            'title',
+            'schema',
+            'schema_path',
+            'specification',
+        )
+        registry = json.load(io.open(REGISTRY_PATH, encoding='utf-8'))
+        for id, item in registry.items():
+            self.assertEqual(sorted(item.keys()), sorted(expected_headers))
+
+    def test_registry_schemas_have_the_required_attributes(self):
+        required_attributes = (
+            'title',
+            'schema',
+            'schema_path',
+            'specification',
+        )
+        registry = json.load(io.open(REGISTRY_PATH, encoding='utf-8'))
+        for id, item in registry.items():
+            for attr in required_attributes:
+                self.assertTrue(attr in item)
+
+    def test_registry_schemas_have_unique_ids(self):
+        ids = []
+        registry = json.load(io.open(REGISTRY_PATH, encoding='utf-8'))
+        for id, item in registry.items():
+            self.assertNotIn(id, ids)
+            ids.append(id)
+
+    def test_schema_paths_exist_and_are_files(self):
+        registry = json.load(io.open(REGISTRY_PATH, encoding='utf-8'))
+        for id, item in registry.items():
+            schema_path = item['schema_path']
+            msg = "schema_path '{0}' of schema '{1}' isn't a file"
+            msg = msg.format(schema_path, id)
+            path = os.path.join(BASE_PATH, schema_path)
+            assert os.path.isfile(path), msg
+
+    def test_schema_urls_exist(self):
+        is_successful = lambda req: req.status >= 200 and req.status < 400
+        is_redirect = lambda req: req.status >= 300 and req.status < 400
+        registry = json.load(io.open(REGISTRY_PATH, encoding='utf-8'))
+        for id, item in registry.items():
+            url = item['schema']
+            res = self._make_head_request(url)
+            msg = "Error fetching schema_url '{0}' of schema '{1}'"
+            msg = msg.format(url, id)
+            assert (is_successful(res) or is_redirect(res)), msg
+
+    def test_specification_urls_exist(self):
+        is_successful = lambda req: req.status >= 200 and req.status < 400
+        is_redirect = lambda req: req.status >= 300 and req.status < 400
+        registry = json.load(io.open(REGISTRY_PATH, encoding='utf-8'))
+        for id, item in registry.items():
+            url = item['schema']
+            res = self._make_head_request(url)
+            msg = "Error fetching specification '{0}' of schema '{1}'"
+            msg = msg.format(url, id)
+            assert (is_successful(res) or is_redirect(res)), msg
+
+    def test_main_schemas_present(self):
+        registry = json.load(io.open(REGISTRY_PATH, encoding='utf-8'))
+        ids = list(registry.keys())
+        self.assertIn('datapackage', ids)
+        self.assertIn('tabular-datapackage', ids)
+        self.assertIn('fiscal-datapackage', ids)
+
+    def _make_head_request(self, url):
+        req = urllib.request.Request(url, method='HEAD')
+        return urllib.request.urlopen(req)


### PR DESCRIPTION
- fixes https://github.com/frictionlessdata/project/issues/294

---

Schema urls update will be in separate PR to address #58 completely (for csv/json).

---

Still not sure why we need to name it Schemas Registry (just a small file with up to 10 items). There so many words like `index`, `catalog` etc. For new comers it could be always confusing what registry does mean (datapackage registry, schema registry etc).

cc @danfowler @pwalsh 